### PR TITLE
FD-101194 - Add support for tsconfig.json files that have an `extends` property

### DIFF
--- a/source/runner/runners/utils/_tests/_fixtures/tsconfig.base.json
+++ b/source/runner/runners/utils/_tests/_fixtures/tsconfig.base.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ES2015"
+  }
+}

--- a/source/runner/runners/utils/_tests/_fixtures/tsconfig.json
+++ b/source/runner/runners/utils/_tests/_fixtures/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.base.json"
+}


### PR DESCRIPTION
When we tried to run `danger` with an extended `tsconfig.json` we ran into issues. Tracked it down to this issue on the `danger-js` repo https://github.com/danger/danger-js/issues/1283.

Following what was suggested in the issue to mimic what `ts-node` is doing to resolve the `tsconfig.json` [here](https://github.com/TypeStrong/ts-node/blob/14323f9d00d5c7051ac09b944c7f423e442145ea/src/configuration.ts#L303). 
Their method is quite a bit more complex since they need to resolve custom `ts-node` compiler options. 

For our purposes, reading the config file using `ts.readConfigFile` and then parsing it with `ts.parseJsonConfigFileContent` produces the expected `tsconfig.json` even when it extends another one.